### PR TITLE
Build conan1.x with python 3.12

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,5 @@
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -69,6 +69,12 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - conan=conans.conan:run
@@ -22,10 +22,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6,<3.12
+    - python >=3.6,<3.13
     - pip
   run:
-    - python >=3.6,<3.12
+    - python >=3.6,<3.13
     - pyjwt >=2.4.0,<3.0.0
     - requests >=2.25,<3.0.0
     - urllib3 >=1.26.6,<1.27

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python >=3.6,<3.13
     - pip
   run:
-    - python >=3.6,<3.13
+    - python >=3.6
     - pyjwt >=2.4.0,<3.0.0
     - requests >=2.25,<3.0.0
     - urllib3 >=1.26.6,<1.27

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
 requirements:
   host:
     - python >=3.6
-    - pip
+    - pip ==24.0
   run:
     - python >=3.6
     - pyjwt >=2.4.0,<3.0.0
@@ -45,7 +45,7 @@ requirements:
 
 test:
   requires:
-    - pip
+    - pip ==24.0
   imports:
     - conans
     - conans.build_info

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6,<3.13
+    - python >=3.6
     - pip
   run:
     - python >=3.6


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Currently conan v1 doesn't work with python 3.12, `mamba install 'python=3.12' 'conan<2'` errors out.
The upper pin was added in https://github.com/conda-forge/conan-feedstock/commit/640f4955233aca304014cd3ba2a9a0e494105a75, I guess as the CI failed? I tried running the feedstock build locally (with `build-locally.py`) and it didn't complain.
With this PR just want to retrigger the build on conda-forge-ci.